### PR TITLE
fix a potential crash caused by a null pointer

### DIFF
--- a/src/Carnac.Logic/ShortcutProvider.cs
+++ b/src/Carnac.Logic/ShortcutProvider.cs
@@ -15,7 +15,11 @@ namespace Carnac.Logic
         {
             string folder = Path.GetDirectoryName(Process.GetCurrentProcess().MainModule.FileName) + @"\Keymaps\";
             string filter = "*.yml";
-            if (!Directory.Exists(folder)) return;
+            if (!Directory.Exists(folder))
+            {
+                shortcuts = new List<ShortcutCollection>();
+                return;
+            }
             string[] files = Directory.GetFiles(folder, filter);
 
             shortcuts = GetYamlMappings(files).Select(GetShortcuts).ToList();


### PR DESCRIPTION
e.g.: if there's no the subfolder "Keymaps", then the whole program will crash and an dialog of error report will be shown by Windows.