### PR TITLE
fix a crash and make the view not closable

### DIFF
--- a/src/Carnac.Logic/Models/PopupSettings.cs
+++ b/src/Carnac.Logic/Models/PopupSettings.cs
@@ -29,7 +29,7 @@ namespace Carnac.Logic.Models
         [DefaultValue("OrangeRed")]
         public string LeftClickColor { get; set; }
 
-        [DefaultValue("RoyaleBlue")]
+        [DefaultValue("RoyalBlue")]
         public string RightClickColor { get; set; }
 
         [DefaultValue(1)]

--- a/src/Carnac.Logic/Win32Methods.cs
+++ b/src/Carnac.Logic/Win32Methods.cs
@@ -16,6 +16,7 @@ namespace Carnac.Logic
         public const int WM_SYSKEYUP = 261;
         public const int WM_SYSKEYDOWN = 260;
         public const int WS_EX_TRANSPARENT = 0x00000020;
+        public const int WS_EX_TOOLWINDOW = 0x00000080;
         public  const int GWL_EXSTYLE = (-20);
 
         //
@@ -40,10 +41,10 @@ namespace Carnac.Logic
         [DllImport("user32.dll")]
         static extern int SetWindowLong(IntPtr hwnd, int index, int newStyle);
 
-        public static void SetWindowExTransparent(IntPtr hwnd)
+        public static void SetWindowExTransparentAndNotInWindowList(IntPtr hwnd)
         {
             var extendedStyle = GetWindowLong(hwnd, GWL_EXSTYLE);
-            SetWindowLong(hwnd, GWL_EXSTYLE, extendedStyle | WS_EX_TRANSPARENT);
+            SetWindowLong(hwnd, GWL_EXSTYLE, extendedStyle | WS_EX_TRANSPARENT | WS_EX_TOOLWINDOW);
         }
     }
 }

--- a/src/Carnac/UI/KeyShowView.xaml.cs
+++ b/src/Carnac/UI/KeyShowView.xaml.cs
@@ -25,7 +25,7 @@ namespace Carnac.UI
             base.OnSourceInitialized(e);
 
             var hwnd = new WindowInteropHelper(this).Handle;
-            Win32Methods.SetWindowExTransparent(hwnd);
+            Win32Methods.SetWindowExTransparentAndNotInWindowList(hwnd);
             var timer = new Timer(100);
             timer.Elapsed +=
                 (s, x) =>

--- a/src/Carnac/UI/PreferencesViewModel.cs
+++ b/src/Carnac/UI/PreferencesViewModel.cs
@@ -46,6 +46,14 @@ namespace Carnac.UI
 
                 AvailableColors.Add(availableColor);
             }
+            if (LeftClickColor == null)
+            {
+                LeftClickColor = new AvailableColor("OrangeRed", Colors.OrangeRed);
+            }
+            if (RightClickColor == null)
+            {
+                RightClickColor = new AvailableColor("RoyalBlue", Colors.RoyalBlue);
+            }
 
             SaveCommand = new DelegateCommand(SaveSettings);
             ResetToDefaultsCommand = new DelegateCommand(() => settingsProvider.ResetToDefaults<PopupSettings>());


### PR DESCRIPTION
The first commit fixes a typo of color name, avoiding crash on saving default settings. The second commit hides the view window from the visible window list of Windows, so a user won't see it when pressing Alt+Tab / Win+Tab, and the process is not listed in "Active Windows" on Taskmgr.