### PR TITLE
ensure the mouse hook is disposed on exit

### DIFF
--- a/src/Carnac/App.xaml.cs
+++ b/src/Carnac/App.xaml.cs
@@ -81,6 +81,7 @@ namespace Carnac
         {
             trayIcon.Dispose();
             carnac.Dispose();
+            keyShowView.Dispose();
             ProcessUtilities.DestroyMutex();
 
             base.OnExit(e);

--- a/src/Carnac/UI/KeyShowView.xaml.cs
+++ b/src/Carnac/UI/KeyShowView.xaml.cs
@@ -9,10 +9,10 @@ using Gma.System.MouseKeyHook;
 
 namespace Carnac.UI
 {
-    public partial class KeyShowView
+    public partial class KeyShowView: IDisposable
     {
         private Storyboard sb;
-        readonly IKeyboardMouseEvents m_GlobalHook = Hook.GlobalEvents();
+        IKeyboardMouseEvents m_GlobalHook = null;
 
         public KeyShowView(KeyShowViewModel keyShowViewModel)
         {
@@ -46,6 +46,14 @@ namespace Carnac.UI
             if (vm.Settings.ShowMouseClicks)
             {
                 SetupMouseEvents();
+            }
+        }
+
+        public void Dispose()
+        {
+            if (m_GlobalHook != null)
+            {
+                m_GlobalHook.Dispose();
             }
         }
 
@@ -130,14 +138,24 @@ namespace Carnac.UI
 
         void SetupMouseEvents()
         {
+            if (m_GlobalHook == null)
+            {
+                m_GlobalHook = Hook.GlobalEvents();
+            }
             m_GlobalHook.MouseDown += OnMouseDown;
             m_GlobalHook.MouseMove += OnMouseMove;
         }
 
         void DestroyMouseEvents()
         {
+            if (m_GlobalHook == null)
+            {
+                return;
+            }
             m_GlobalHook.MouseDown -= OnMouseDown;
             m_GlobalHook.MouseMove -= OnMouseMove;
+            m_GlobalHook.Dispose();
+            m_GlobalHook = null;
         }
 
         private void OnMouseDown(object sender, System.Windows.Forms.MouseEventArgs e)


### PR DESCRIPTION
If not calling `m_GlobalHook.Dispose();`, then the program may just be running `OnMouseMove` when it's to exit. If it runs into this case, an exception is thrown and the mouse hook doesn't return to system correctly, so mouse gets trapped and you can not move it any more - until Windows finds a timeout in seconds and resets mouse.

Also try to unload this hook if possible, mainly for lowest CPU cost (0.2% -> 0%).